### PR TITLE
feat: add Airflow trigger action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 >ruff check .
 
 chart-lint:
->helm lint deploy/airflow deploy/datahub
+>helm lint deploy/airflow deploy/datahub deploy/airflow-trigger
 
 test:
 >pytest tests/unit tests/contract tests/e2e

--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -1,0 +1,1 @@
+"""Custom DataHub Actions."""

--- a/actions/airflow_trigger/__init__.py
+++ b/actions/airflow_trigger/__init__.py
@@ -1,0 +1,5 @@
+"""Airflow Trigger Action package."""
+
+from .action import AirflowTriggerAction
+
+__all__ = ["AirflowTriggerAction"]

--- a/actions/airflow_trigger/action.py
+++ b/actions/airflow_trigger/action.py
@@ -1,0 +1,113 @@
+"""DataHub action that triggers Airflow DAG runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+import yaml
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+trigger_counter = Counter(
+    "airflow_trigger_total", "Total Airflow trigger events", ["status"]
+)
+
+
+class AirflowTriggerAction:
+    """Trigger Airflow DAGs based on DataHub events."""
+
+    def __init__(
+        self,
+        airflow_url: str,
+        mappings_path: str,
+        *,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        token: Optional[str] = None,
+        max_retries: int = 3,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.airflow_url = airflow_url.rstrip("/")
+        self.username = username
+        self.password = password
+        self.token = token
+        self.max_retries = max_retries
+        self.session = session or requests.Session()
+        with open(mappings_path, "r", encoding="utf-8") as f:
+            self.mappings: Dict[str, Dict[str, Any]] = yaml.safe_load(f) or {}
+
+    @staticmethod
+    def _dag_run_id(dag_id: str, event: Dict[str, Any]) -> str:
+        """Build a deterministic dag_run_id from the event."""
+        payload = json.dumps(event, sort_keys=True)
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:8]
+        return f"{dag_id}-{digest}"
+
+    def _resolve_conf(self, conf_template: Dict[str, Any], event: Dict[str, Any]) -> Dict[str, Any]:
+        conf: Dict[str, Any] = {}
+        for key, value in conf_template.items():
+            if isinstance(value, str) and value.startswith("{{") and value.endswith("}}"): 
+                event_key = value.strip("{} ")
+                conf[key] = event.get(event_key)
+            else:
+                conf[key] = value
+        return conf
+
+    def trigger(self, event: Dict[str, Any]) -> str:
+        """Trigger a DAG run for the given event."""
+        event_type = event.get("type")
+        mapping = self.mappings.get(event_type)
+        if not mapping:
+            logger.warning("event type %s not mapped", event_type)
+            trigger_counter.labels(status="ignored").inc()
+            raise ValueError(f"event type {event_type} not whitelisted")
+
+        dag_id = mapping["dag_id"]
+        conf_template = mapping.get("conf", {})
+        conf = self._resolve_conf(conf_template, event)
+        dag_run_id = self._dag_run_id(dag_id, event)
+
+        headers = {"Content-Type": "application/json"}
+        auth = None
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        elif self.username and self.password:
+            auth = (self.username, self.password)
+
+        url = f"{self.airflow_url}/api/v1/dags/{dag_id}/dagRuns"
+        payload = {"dag_run_id": dag_run_id, "conf": conf}
+
+        for attempt in range(1, self.max_retries + 1):
+            response = self.session.post(url, json=payload, headers=headers, auth=auth)
+            if response.status_code in {401, 403}:
+                trigger_counter.labels(status="unauthorized").inc()
+                logger.error("unauthorized to trigger %s: %s", dag_id, response.text)
+                response.raise_for_status()
+            if response.status_code >= 500:
+                logger.warning(
+                    "error triggering %s (status %s), attempt %s", dag_id, response.status_code, attempt
+                )
+                if attempt == self.max_retries:
+                    trigger_counter.labels(status="error").inc()
+                    response.raise_for_status()
+                continue
+            try:
+                response.raise_for_status()
+            except requests.HTTPError:
+                trigger_counter.labels(status="error").inc()
+                logger.error("failed to trigger %s: %s", dag_id, response.text)
+                raise
+            trigger_counter.labels(status="success").inc()
+            logger.info(
+                "triggered dag", extra={"dag_id": dag_id, "dag_run_id": dag_run_id}
+            )
+            return dag_run_id
+
+        # Should never reach here
+        trigger_counter.labels(status="error").inc()
+        raise RuntimeError("Failed to trigger DAG after retries")

--- a/actions/config/mappings.dev.yaml
+++ b/actions/config/mappings.dev.yaml
@@ -1,0 +1,4 @@
+sample_event:
+  dag_id: sample_dag
+  conf:
+    foo: bar

--- a/deploy/airflow-trigger/Chart.yaml
+++ b/deploy/airflow-trigger/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: airflow-trigger
+version: 0.1.0

--- a/deploy/airflow-trigger/templates/configmap.yaml
+++ b/deploy/airflow-trigger/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airflow-trigger-mappings
+data:
+  mappings.yaml: |
+{{ .Values.mappings | indent 4 }}

--- a/deploy/airflow-trigger/templates/deployment.yaml
+++ b/deploy/airflow-trigger/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-trigger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airflow-trigger
+  template:
+    metadata:
+      labels:
+        app: airflow-trigger
+    spec:
+      containers:
+        - name: airflow-trigger
+          image: {{ .Values.image }}
+          env:
+            - name: AIRFLOW_API_BASE_URL
+              value: {{ .Values.airflow.url | quote }}
+            - name: MAPPINGS_PATH
+              value: /app/config/mappings.yaml
+          volumeMounts:
+            - name: mappings
+              mountPath: /app/config
+      volumes:
+        - name: mappings
+          configMap:
+            name: airflow-trigger-mappings

--- a/deploy/airflow-trigger/values.dev.yaml
+++ b/deploy/airflow-trigger/values.dev.yaml
@@ -1,0 +1,2 @@
+# Development overrides
+image: example/airflow-trigger:dev

--- a/deploy/airflow-trigger/values.yaml
+++ b/deploy/airflow-trigger/values.yaml
@@ -1,0 +1,8 @@
+image: example/airflow-trigger:latest
+airflow:
+  url: http://airflow-webserver:8080
+mappings: |
+  sample_event:
+    dag_id: sample_dag
+    conf:
+      foo: bar

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,0 +1,29 @@
+# Airflow Trigger Action
+
+The Airflow Trigger action listens for DataHub events and invokes the Airflow
+REST API to start DAG runs. Event types are mapped to Airflow DAG IDs and
+optional run configuration via a YAML file.
+
+## Configuration
+
+`actions/config/mappings.dev.yaml`
+
+```yaml
+sample_event:
+  dag_id: sample_dag
+  conf:
+    foo: bar
+```
+
+## Environment Variables
+
+- `AIRFLOW_API_BASE_URL` – base URL for the Airflow REST API.
+- `AIRFLOW_USERNAME` / `AIRFLOW_PASSWORD` – credentials for basic auth.
+- `AIRFLOW_TOKEN` – bearer token (takes precedence over basic auth).
+- `MAPPINGS_PATH` – path to the mappings YAML file.
+
+## Notes
+
+This action is built on top of DataHub's Actions framework, which must be
+enabled in your deployment. See the [DataHub Actions framework](datahub.md) for more information.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pytest
 ruff
 requests
+PyYAML
+prometheus-client

--- a/tests/unit/test_airflow_trigger_action.py
+++ b/tests/unit/test_airflow_trigger_action.py
@@ -1,0 +1,95 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import requests
+from actions.airflow_trigger import AirflowTriggerAction
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, text: str = "ok"):
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(self.text)
+
+
+def test_mapping_and_conf(monkeypatch, tmp_path):
+    path = tmp_path / "mappings.yaml"
+    path.write_text("sample_event:\n  dag_id: d1\n  conf:\n    foo: '{{bar}}'\n")
+
+    session_calls = {}
+
+    class Session:
+        def post(self, url, json, headers, auth):
+            session_calls["url"] = url
+            session_calls["json"] = json
+            return DummyResponse(200)
+
+    action = AirflowTriggerAction("http://airflow", str(path), session=Session())
+    event = {"type": "sample_event", "bar": "baz"}
+    dag_run_id = action.trigger(event)
+
+    assert session_calls["url"].endswith("/api/v1/dags/d1/dagRuns")
+    assert session_calls["json"]["conf"]["foo"] == "baz"
+    assert dag_run_id.startswith("d1-")
+
+
+def test_idempotent_dag_run_id(tmp_path):
+    path = tmp_path / "mappings.yaml"
+    path.write_text("sample_event:\n  dag_id: test\n")
+    action = AirflowTriggerAction("http://airflow", str(path))
+    event = {"type": "sample_event", "id": 1}
+    first = action._dag_run_id("test", event)
+    second = action._dag_run_id("test", event)
+    assert first == second
+
+
+def test_retry_on_server_error(tmp_path):
+    path = tmp_path / "mappings.yaml"
+    path.write_text("sample_event:\n  dag_id: d1\n")
+    calls = {"count": 0}
+
+    class Session:
+        def post(self, url, json, headers, auth):
+            calls["count"] += 1
+            if calls["count"] < 2:
+                return DummyResponse(500, "error")
+            return DummyResponse(200)
+
+    action = AirflowTriggerAction("http://airflow", str(path), session=Session())
+    event = {"type": "sample_event"}
+    dag_run_id = action.trigger(event)
+    assert calls["count"] == 2
+    assert dag_run_id.startswith("d1-")
+
+
+def test_unauthorized(tmp_path):
+    path = tmp_path / "mappings.yaml"
+    path.write_text("sample_event:\n  dag_id: d1\n")
+
+    class Session:
+        def post(self, url, json, headers, auth):
+            return DummyResponse(401, "unauthorized")
+
+    action = AirflowTriggerAction("http://airflow", str(path), session=Session())
+    event = {"type": "sample_event"}
+    try:
+        action.trigger(event)
+    except requests.HTTPError:
+        pass
+    else:
+        assert False, "Expected HTTPError"
+
+
+def test_non_whitelisted(tmp_path):
+    path = tmp_path / "mappings.yaml"
+    path.write_text("other_event:\n  dag_id: d1\n")
+    action = AirflowTriggerAction("http://airflow", str(path))
+    event = {"type": "sample_event"}
+    try:
+        action.trigger(event)
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError"


### PR DESCRIPTION
## Summary
- implement Airflow Trigger action with mapping, auth, retries and metrics
- helm chart and config for running the action
- documentation and unit tests for mapping, idempotency and retry

## Testing
- `ruff check .`
- `helm lint deploy/airflow deploy/datahub deploy/airflow-trigger` *(fails: command not found)*
- `pytest tests/unit tests/contract tests/e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af22a34628832c9c05c911cb69c09c