### PR TITLE
Fix lint failure by splitting imports

### DIFF
--- a/tests/unit/test_airflow_trigger_action.py
+++ b/tests/unit/test_airflow_trigger_action.py
@@ -1,4 +1,6 @@
-import sys, pathlib
+import sys
+import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 import requests
 from actions.airflow_trigger import AirflowTriggerAction


### PR DESCRIPTION
## Summary
- split combined imports in unit test to satisfy ruff

## Testing
- `make lint`
- `make chart-lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af24785a0c832c9798aec6ced9135e