### PR TITLE
ci: install dependencies for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - run: pip install pytest
+      - run: pip install -r requirements.txt
       - run: pytest tests/unit


### PR DESCRIPTION
## Summary
- install project requirements before running unit tests to include requests and other dependencies

## Testing
- `ruff check .`
- `pytest tests/unit tests/contract tests/e2e`


------
https://chatgpt.com/codex/tasks/task_e_68af28322734832c95afd732eb28159e