### PR TITLE
Secure Airflow API access

### DIFF
--- a/deploy/airflow-trigger/templates/deployment.yaml
+++ b/deploy/airflow-trigger/templates/deployment.yaml
@@ -18,6 +18,11 @@ spec:
           env:
             - name: AIRFLOW_API_BASE_URL
               value: {{ .Values.airflow.url | quote }}
+            - name: AIRFLOW_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-api-token
+                  key: token
             - name: MAPPINGS_PATH
               value: /app/config/mappings.yaml
           volumeMounts:

--- a/deploy/airflow-trigger/templates/secret.yaml
+++ b/deploy/airflow-trigger/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-api-token
+type: Opaque
+stringData:
+  token: {{ .Values.airflow.token | quote }}

--- a/deploy/airflow-trigger/values.yaml
+++ b/deploy/airflow-trigger/values.yaml
@@ -1,6 +1,7 @@
 image: example/airflow-trigger:latest
 airflow:
-  url: http://airflow-webserver:8080
+  url: https://airflow-webserver:8080
+  token: ""
 mappings: |
   sample_event:
     dag_id: sample_dag

--- a/deploy/airflow/templates/ingress.yaml
+++ b/deploy/airflow/templates/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: airflow
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecret }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: airflow-webserver
+                port:
+                  number: 8080

--- a/deploy/airflow/templates/networkpolicy.yaml
+++ b/deploy/airflow/templates/networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: airflow-api
+spec:
+  podSelector:
+    matchLabels:
+      app: airflow
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: airflow-trigger
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/deploy/airflow/values.yaml
+++ b/deploy/airflow/values.yaml
@@ -1,1 +1,3 @@
-# placeholder values
+ingress:
+  host: airflow.example.com
+  tlsSecret: airflow-tls

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,24 @@
 # Security
+
 - **AuthN to Airflow REST API**: token or mTLS; never anonymous.
 - **AuthZ**: DAG allowlist; per-DAG concurrency caps.
 - **Secrets**: store in Kubernetes Secrets; never commit secrets.
 - **Network**: restrict egress; only DataHub Action can reach Airflow API.
 - **Audit**: log who/what/when; retain 30–90 days.
+
+## Token management
+- API tokens live in the `airflow-api-token` Secret and are mounted as `AIRFLOW_API_TOKEN`.
+- Rotate tokens by updating the Secret and restarting the `airflow-trigger` Deployment:
+  ```bash
+  kubectl create secret generic airflow-api-token --from-literal token=<new> -o yaml --dry-run=client | kubectl apply -f -
+  kubectl rollout restart deploy/airflow-trigger
+  ```
+- Store rotation history and expiry dates in your secret manager or runbook.
+
+## Network policy
+- `NetworkPolicy` restricts inbound traffic to the Airflow webserver to pods labeled `app=airflow-trigger`.
+- Verify with `kubectl exec` from a random pod; calls should time out or be dropped.
+
+## TLS
+- Airflow Ingress terminates TLS using the `airflow-tls` secret.
+- DataHub Action calls `https://` endpoints and relies on the cluster trust store to validate certificates.

--- a/tests/contract/test_airflow_api.py
+++ b/tests/contract/test_airflow_api.py
@@ -5,8 +5,7 @@ import pytest
 import requests
 
 API_URL = os.getenv("AIRFLOW_API_URL")
-API_USER = os.getenv("AIRFLOW_API_USERNAME")
-API_PASSWORD = os.getenv("AIRFLOW_API_PASSWORD")
+API_TOKEN = os.getenv("AIRFLOW_API_TOKEN")
 
 
 @pytest.fixture(scope="module")
@@ -22,13 +21,23 @@ def test_api_requires_auth(airflow_url):
     assert resp.status_code == 401
 
 
-def test_api_accepts_basic_auth(airflow_url):
-    if not API_USER or not API_PASSWORD:
-        pytest.skip("AIRFLOW_API_USERNAME and AIRFLOW_API_PASSWORD are required")
+def test_api_rejects_bad_token(airflow_url):
     dag_id = "example_bash_operator"
     resp = requests.post(
         f"{airflow_url}/api/v1/dags/{dag_id}/dagRuns",
-        auth=(API_USER, API_PASSWORD),
+        headers={"Authorization": "Bearer wrong"},
+        json={"dag_run_id": f"dev-{uuid4()}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_api_accepts_token(airflow_url):
+    if not API_TOKEN:
+        pytest.skip("AIRFLOW_API_TOKEN is required")
+    dag_id = "example_bash_operator"
+    resp = requests.post(
+        f"{airflow_url}/api/v1/dags/{dag_id}/dagRuns",
+        headers={"Authorization": f"Bearer {API_TOKEN}"},
         json={"dag_run_id": f"dev-{uuid4()}"},
     )
     assert 200 <= resp.status_code < 400


### PR DESCRIPTION
## Summary
- add NetworkPolicy limiting Airflow API access to the airflow-trigger pod
- store Airflow API token in a Secret and mount it to the trigger action
- expose Airflow via TLS-terminated Ingress
- document token rotation and network policy enforcement
- cover 401/403 responses in contract tests

## Testing
- `make lint`
- `make chart-lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af2924e8a4832cbb712efc4b6723c2