### PR TITLE
Add example DAGs and trigger tests

### DIFF
--- a/deploy/airflow/dags/example_event_dag.py
+++ b/deploy/airflow/dags/example_event_dag.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+
+def log_conf(**context):
+    conf = context.get("dag_run").conf or {}
+    print(f"Received payload: {conf}")
+
+
+with DAG(
+    dag_id="example_event_dag",
+    description="Logs incoming conf payload from DataHub trigger",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["example"],
+) as dag:
+    PythonOperator(task_id="log_conf", python_callable=log_conf)

--- a/deploy/airflow/dags/example_quality_check.py
+++ b/deploy/airflow/dags/example_quality_check.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+
+def quality_check(**context):
+    conf = context.get("dag_run").conf or {}
+    dataset = conf.get("dataset")
+    print(f"Running quality check for {dataset}")
+
+
+with DAG(
+    dag_id="example_quality_check",
+    description="Simulated data quality run",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["example"],
+) as dag:
+    PythonOperator(task_id="run_quality_check", python_callable=quality_check)

--- a/deploy/airflow/values.dev.yaml
+++ b/deploy/airflow/values.dev.yaml
@@ -27,3 +27,11 @@ scheduler:
 airflow:
   config:
     AIRFLOW__API__AUTH_BACKEND: airflow.api.auth.backend.basic_auth
+
+# Example DAGs pulled from repo for automatic discovery
+dags:
+  gitSync:
+    enabled: true
+    repo: https://github.com/datahub-project/datahub-airflow-orchestrator.git
+    branch: main
+    subPath: deploy/airflow/dags

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -5,3 +5,5 @@
 
 ## Examples
 - Tag `gold:daily-refresh` → `dag_id: refresh_gold_tables`, `conf: { datasets: [...] }`.
+- Dataset URN `urn:li:dataset:(urn:li:dataPlatform:sample,foo,PROD)` → `dag_id: example_event_dag`, `conf: {"dataset": <URN>}`.
+- Dataset tagged `needs-quality-check` → `dag_id: example_quality_check`, `conf: {"dataset": <URN>}`.

--- a/tests/e2e/test_example_dags.py
+++ b/tests/e2e/test_example_dags.py
@@ -1,0 +1,67 @@
+import os
+import time
+import subprocess
+import shutil
+
+import pytest
+import requests
+
+NAMESPACE = os.getenv("AIRFLOW_NAMESPACE", "airflow-dev")
+RELEASE = os.getenv("AIRFLOW_RELEASE", "airflow-dev")
+AIRFLOW_USER = os.getenv("AIRFLOW_USER", "admin")
+AIRFLOW_PASSWORD = os.getenv("AIRFLOW_PASSWORD", "")
+
+
+def _port_forward(service: str, local_port: int, remote_port: int):
+    if not shutil.which("kubectl"):
+        pytest.skip("kubectl not installed")
+    proc = subprocess.Popen(
+        [
+            "kubectl",
+            "port-forward",
+            f"svc/{service}",
+            f"{local_port}:{remote_port}",
+            "-n",
+            NAMESPACE,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(3)
+    if proc.poll() is not None:
+        pytest.skip(f"port-forward failed for {service}")
+    return proc
+
+
+def _trigger_and_wait(dag_id: str, conf: dict | None = None):
+    service = f"{RELEASE}-webserver"
+    proc = _port_forward(service, 8080, 8080)
+    try:
+        url = f"http://localhost:8080/api/v1/dags/{dag_id}/dagRuns"
+        auth = (AIRFLOW_USER, AIRFLOW_PASSWORD)
+        try:
+            resp = requests.post(url, json={"conf": conf or {}}, auth=auth, timeout=5)
+        except requests.RequestException:
+            pytest.skip("Airflow API not reachable")
+        if resp.status_code >= 400:
+            pytest.skip("Airflow API unavailable")
+        dag_run_id = resp.json()["dag_run_id"]
+        for _ in range(30):
+            try:
+                status = requests.get(f"{url}/{dag_run_id}", auth=auth, timeout=5)
+            except requests.RequestException:
+                pytest.skip("Airflow API not reachable")
+            state = status.json().get("state")
+            if state in {"success", "failed"}:
+                break
+            time.sleep(1)
+        assert state == "success"
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+def test_example_dags_reach_success():
+    conf = {"dataset": "urn:li:dataset:(urn:li:dataPlatform:sample,foo,PROD)"}
+    for dag_id in ["example_event_dag", "example_quality_check"]:
+        _trigger_and_wait(dag_id, conf)


### PR DESCRIPTION
## Summary
- add example event and quality check DAGs
- configure values to git-sync example DAGs
- e2e test triggers DAGs and verifies run completion
- document event to DAG mappings

## Testing
- `make lint`
- `make chart-lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af2a4d20a4832c9fbbefd70ea79311