### PR TITLE
feat: add correlation ids and metrics

### DIFF
--- a/actions/airflow_trigger/action.py
+++ b/actions/airflow_trigger/action.py
@@ -9,13 +9,21 @@ from typing import Any, Dict, Optional
 
 import requests
 import yaml
-from prometheus_client import Counter
+import uuid
+import time
+from prometheus_client import Counter, Histogram
 
 logger = logging.getLogger(__name__)
 
 trigger_counter = Counter(
     "airflow_trigger_total", "Total Airflow trigger events", ["status"]
 )
+
+triggers_total = Counter("triggers_total", "Total trigger attempts")
+trigger_failures_total = Counter(
+    "trigger_failures_total", "Total trigger failures"
+)
+latency_ms = Histogram("latency_ms", "Trigger latency in milliseconds")
 
 
 class AirflowTriggerAction:
@@ -65,54 +73,75 @@ class AirflowTriggerAction:
 
     def trigger(self, event: Dict[str, Any]) -> str:
         """Trigger a DAG run for the given event."""
-        event_type = event.get("type")
-        mapping = self.mappings.get(event_type)
-        if not mapping:
-            logger.warning("event type %s not mapped", event_type)
-            trigger_counter.labels(status="ignored").inc()
-            raise ValueError(f"event type {event_type} not whitelisted")
+        start_time = time.time()
+        triggers_total.inc()
+        correlation_id = str(uuid.uuid4())
+        extra = {"correlation_id": correlation_id}
+        try:
+            event_type = event.get("type")
+            mapping = self.mappings.get(event_type)
+            if not mapping:
+                logger.warning("event type %s not mapped", event_type, extra=extra)
+                trigger_counter.labels(status="ignored").inc()
+                raise ValueError(f"event type {event_type} not whitelisted")
 
-        dag_id = mapping["dag_id"]
-        conf_template = mapping.get("conf", {})
-        conf = self._resolve_conf(conf_template, event)
-        dag_run_id = self._dag_run_id(dag_id, event)
+            dag_id = mapping["dag_id"]
+            conf_template = mapping.get("conf", {})
+            conf = self._resolve_conf(conf_template, event)
+            conf["correlation_id"] = correlation_id
+            dag_run_id = self._dag_run_id(dag_id, event)
+            extra.update({"dag_id": dag_id, "dag_run_id": dag_run_id})
 
-        headers = {"Content-Type": "application/json"}
-        auth = None
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-        elif self.username and self.password:
-            auth = (self.username, self.password)
+            headers = {
+                "Content-Type": "application/json",
+                "X-Correlation-ID": correlation_id,
+            }
+            auth = None
+            if self.token:
+                headers["Authorization"] = f"Bearer {self.token}"
+            elif self.username and self.password:
+                auth = (self.username, self.password)
 
-        url = f"{self.airflow_url}/api/v1/dags/{dag_id}/dagRuns"
-        payload = {"dag_run_id": dag_run_id, "conf": conf}
+            url = f"{self.airflow_url}/api/v1/dags/{dag_id}/dagRuns"
+            payload = {"dag_run_id": dag_run_id, "conf": conf}
 
-        for attempt in range(1, self.max_retries + 1):
-            response = self.session.post(url, json=payload, headers=headers, auth=auth)
-            if response.status_code in {401, 403}:
-                trigger_counter.labels(status="unauthorized").inc()
-                logger.error("unauthorized to trigger %s: %s", dag_id, response.text)
-                response.raise_for_status()
-            if response.status_code >= 500:
-                logger.warning(
-                    "error triggering %s (status %s), attempt %s", dag_id, response.status_code, attempt
-                )
-                if attempt == self.max_retries:
-                    trigger_counter.labels(status="error").inc()
+            for attempt in range(1, self.max_retries + 1):
+                response = self.session.post(url, json=payload, headers=headers, auth=auth)
+                if response.status_code in {401, 403}:
+                    trigger_counter.labels(status="unauthorized").inc()
+                    logger.error(
+                        "unauthorized to trigger %s: %s", dag_id, response.text, extra=extra
+                    )
                     response.raise_for_status()
-                continue
-            try:
-                response.raise_for_status()
-            except requests.HTTPError:
-                trigger_counter.labels(status="error").inc()
-                logger.error("failed to trigger %s: %s", dag_id, response.text)
-                raise
-            trigger_counter.labels(status="success").inc()
-            logger.info(
-                "triggered dag", extra={"dag_id": dag_id, "dag_run_id": dag_run_id}
-            )
-            return dag_run_id
+                if response.status_code >= 500:
+                    logger.warning(
+                        "error triggering %s (status %s), attempt %s",
+                        dag_id,
+                        response.status_code,
+                        attempt,
+                        extra=extra,
+                    )
+                    if attempt == self.max_retries:
+                        trigger_counter.labels(status="error").inc()
+                        response.raise_for_status()
+                    continue
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError:
+                    trigger_counter.labels(status="error").inc()
+                    logger.error(
+                        "failed to trigger %s: %s", dag_id, response.text, extra=extra
+                    )
+                    raise
+                trigger_counter.labels(status="success").inc()
+                logger.info("triggered dag", extra=extra)
+                return dag_run_id
 
-        # Should never reach here
-        trigger_counter.labels(status="error").inc()
-        raise RuntimeError("Failed to trigger DAG after retries")
+            # Should never reach here
+            trigger_counter.labels(status="error").inc()
+            raise RuntimeError("Failed to trigger DAG after retries")
+        except Exception:
+            trigger_failures_total.inc()
+            raise
+        finally:
+            latency_ms.observe((time.time() - start_time) * 1000)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,7 +1,31 @@
 # Observability
-- **Correlation ID**: add `X-Correlation-ID` to every trigger.
-- **Metrics**: triggers_total, trigger_failures_total, latency_ms.
-- **Logs**: structured logs on both sides (DataHub Action & Airflow).
+
+The orchestrator exposes request-level tracing and basic Prometheus metrics.
+
+## Correlation IDs
+- Every trigger generates a UUID4 correlation ID.
+- Sent as the `X-Correlation-ID` HTTP header and embedded in the Airflow
+  `conf` payload (`conf.correlation_id`).
+- All log lines emitted by the action include the `correlation_id` field so
+  DataHub and Airflow logs can be joined.
+
+## Metrics
+- `triggers_total` – counter of all trigger attempts.
+- `trigger_failures_total` – counter of failed trigger attempts.
+- `latency_ms` – histogram of trigger round-trip latency in milliseconds.
+
+Expose metrics for scraping with:
+
+```python
+from prometheus_client import start_http_server
+start_http_server(8000)
+```
+
+Then `curl http://localhost:8000/metrics` to inspect the values.
+
+## Logs
+- Structured logging on both sides (DataHub Action & Airflow) includes the
+  shared `correlation_id`.
 
 ## SLOs
 - Trigger ack latency < 5s (p95).


### PR DESCRIPTION
## Summary
- generate X-Correlation-ID for each trigger and pass to Airflow
- expose Prometheus metrics (triggers_total, trigger_failures_total, latency_ms)
- document observability setup

## Testing
- `make lint`
- `make chart-lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af2c8a26e8832caee4b26da3feab19