### PR TITLE
Add DLQ, retries with backoff, and health circuit breaker

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,4 +7,12 @@
 - Validate mapping rules; ensure DAG is deployed and discoverable.
 
 ## Timeouts / 5xx
-- Check Airflow health; activate retries and DLQ; consider back-pressure.
+- The action automatically retries with exponential backoff and writes
+  failed events to a **dead-letter queue** file (DLQ).
+- Inspect the DLQ at the configured path and use `scripts/replay_dlq.py`
+  to resubmit once Airflow is healthy.
+
+## Airflow health is red
+- The trigger performs a health check before submitting. When Airflow
+  reports unhealthy, new events are placed on the DLQ instead of being
+  sent.

--- a/scripts/replay_dlq.py
+++ b/scripts/replay_dlq.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Replay DLQ events to Airflow."""
+
+import argparse
+import json
+from typing import List
+
+from actions.airflow_trigger import AirflowTriggerAction
+
+
+def replay(dlq_path: str, action: AirflowTriggerAction) -> None:
+    """Read events from ``dlq_path`` and attempt to replay them.
+
+    Successful events are removed from the DLQ. Failed events are written back.
+    """
+    remaining: List[dict] = []
+    try:
+        with open(dlq_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        lines = []
+    for line in lines:
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        event = entry.get("event", {})
+        try:
+            action.trigger(event)
+        except Exception as e:  # pragma: no cover - re-queue failures
+            entry["error"] = str(e)
+            remaining.append(entry)
+    with open(dlq_path, "w", encoding="utf-8") as f:
+        for entry in remaining:
+            f.write(json.dumps(entry) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay DLQ events")
+    parser.add_argument("--airflow-url", required=True)
+    parser.add_argument("--mappings", required=True)
+    parser.add_argument("--dlq", required=True)
+    parser.add_argument("--username")
+    parser.add_argument("--password")
+    parser.add_argument("--token")
+    args = parser.parse_args()
+
+    action = AirflowTriggerAction(
+        args.airflow_url,
+        args.mappings,
+        username=args.username,
+        password=args.password,
+        token=args.token,
+        dlq_path=None,
+    )
+    replay(args.dlq, action)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add exponential backoff, DLQ persistence, and health-based circuit breaker to Airflow trigger action
- add replay script for DLQ events
- document troubleshooting for retries, DLQ, and health checks

## Testing
- `make lint`
- `make chart-lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af2e22ea68832c859a59a4c68d9c11