### PR TITLE
Add timeouts to HTTP requests in tests

### DIFF
--- a/tests/contract/test_airflow_api.py
+++ b/tests/contract/test_airflow_api.py
@@ -17,7 +17,9 @@ def airflow_url():
 
 def test_api_requires_auth(airflow_url):
     dag_id = "example_bash_operator"
-    resp = requests.post(f"{airflow_url}/api/v1/dags/{dag_id}/dagRuns")
+    resp = requests.post(
+        f"{airflow_url}/api/v1/dags/{dag_id}/dagRuns", timeout=5
+    )
     assert resp.status_code == 401
 
 
@@ -27,6 +29,7 @@ def test_api_rejects_bad_token(airflow_url):
         f"{airflow_url}/api/v1/dags/{dag_id}/dagRuns",
         headers={"Authorization": "Bearer wrong"},
         json={"dag_run_id": f"dev-{uuid4()}"},
+        timeout=5,
     )
     assert resp.status_code == 403
 
@@ -39,5 +42,6 @@ def test_api_accepts_token(airflow_url):
         f"{airflow_url}/api/v1/dags/{dag_id}/dagRuns",
         headers={"Authorization": f"Bearer {API_TOKEN}"},
         json={"dag_run_id": f"dev-{uuid4()}"},
+        timeout=5,
     )
     assert 200 <= resp.status_code < 400

--- a/tests/unit/test_airflow_trigger_action.py
+++ b/tests/unit/test_airflow_trigger_action.py
@@ -210,7 +210,9 @@ def test_correlation_id_and_metrics(tmp_path, caplog):
     record = next(r for r in caplog.records if "triggered dag" in r.message)
     assert getattr(record, "correlation_id") == corr_id
 
-    metrics = requests.get(f"http://localhost:{port}/metrics").text
+    metrics = requests.get(
+        f"http://localhost:{port}/metrics", timeout=5
+    ).text
     assert "triggers_total" in metrics
     assert "latency_ms" in metrics
 


### PR DESCRIPTION
## Summary
- prevent hangs by specifying timeouts for Airflow API requests in contract tests
- avoid indefinite waits on metrics endpoint in unit test by adding timeout

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af43a2b9e8832c9184027b825c4c71